### PR TITLE
Run end-to-end tests against every push

### DIFF
--- a/.github/actions/end-to-end-tests/action.yml
+++ b/.github/actions/end-to-end-tests/action.yml
@@ -1,0 +1,68 @@
+name: 🧪 End-to-end tests
+
+inputs:
+  url:
+    required: false
+    type: string
+  auth-bypass-token:
+    required: false
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: ⬇️ Checkout repo
+      uses: actions/checkout@v4
+
+    - name: 📥 Install dependencies
+      shell: 'bash'
+      run: npm ci
+
+    - name: 📦 Build
+      shell: 'bash'
+      run: npm run build
+
+    - name: 💾 Turbo cache
+      id: turbo-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules/.cache/turbo
+          **/.turbo
+        key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ github.job }}-${{ github.ref_name }}-
+
+    - name: 📄 Get installed Playwright version
+      shell: 'bash'
+      run: echo "PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright -m 1 | sed 's/.*@//')"  >> $GITHUB_ENV
+
+    - name: 💾 Cache Playwright binaries
+      uses: actions/cache@v3
+      id: playwright-cache
+      with:
+        path: |
+          ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+    - name: 💽 Install Playwright Browsers (all)
+      shell: 'bash'
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps chromium
+
+    - name: 💽 Install Playwright (only system deps)
+      shell: 'bash'
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps chromium
+
+    - name: 🍄 Run Playwright tests
+      shell: 'bash'
+      run: URL=${{ inputs.url }} AUTH_BYPASS_TOKEN=${{ inputs.auth-bypass-token }} npx playwright test
+
+    - name: 🗒 Report
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: ./playwright-report/
+        retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm run format:check
 
   typecheck:
-    name: Typescript
+    name: ⬣ Typescript
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
@@ -94,7 +94,7 @@ jobs:
         run: 'test -z "$(git status --porcelain "packages/cli/oclif.manifest.json" )" || { echo -e "Run npm generate:manifest in packages/cli before pushing new commands or flags. Diff here:\n\n$(git diff)" ; exit 1; }'
 
   e2e:
-    name: ⚫️ Playwright tests
+    name: ⬣ Playwright tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
@@ -104,56 +104,5 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
 
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: 📥 Install dependencies
-        run: npm ci
-
-      - name: 📦 Build
-        run: npm run build
-
-      - name: 💾 Turbo cache
-        id: turbo-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules/.cache/turbo
-            **/.turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-
-
-      - name: 📄 Get installed Playwright version
-        run: echo "PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright -m 1 | sed 's/.*@//')"  >> $GITHUB_ENV
-
-      - name: 💾 Cache Playwright binaries
-        uses: actions/cache@v3
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-      - name: 💽 Install Playwright Browsers (all)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      - name: 💽 Install Playwright (only system deps)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
-
-      - name: 🍄 Run Playwright tests
-        run: npx playwright test
-
-      - name: 🗒 Report
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: ./playwright-report/
-          retention-days: 30
+      - name: 🧪 Run Playwright tests
+        uses: ./.github/actions/end-to-end-tests

--- a/.github/workflows/oxygen-deployment-1000013955.yml
+++ b/.github/workflows/oxygen-deployment-1000013955.yml
@@ -40,17 +40,14 @@ jobs:
 
       - name: Build and Publish to Oxygen
         id: deploy
-        uses: shopify/oxygenctl-action@v4
-        with:
-          oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_1000013955 }}
-          build_command: 'npm run build'
+        run: |
+          npx shopify hydrogen deploy --auth-bypass-token --token "${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_1000013955 }}"
+          echo "AUTH_BYPASS_TOKEN=$(jq -r '.authBypassToken' h2_deploy_log.json)" >> $GITHUB_ENV
+          echo "DEPLOYMENT_URL=$(jq -r '.url' h2_deploy_log.json)" >> $GITHUB_ENV
 
-      # Create GitHub Deployment
-      - name: Create GitHub Deployment
-        uses: shopify/github-deployment-action@v1
-        if: always()
+      - name: Run end-to-end tests
+        id: end-to-end-tests
+        uses: ./.github/actions/end-to-end-tests
         with:
-          token: ${{ github.token }}
-          environment: 'preview'
-          preview_url: ${{ steps.deploy.outputs.url }}
-          description: ${{ github.event.head_commit.message }}
+          url: ${{ env.DEPLOYMENT_URL }}
+          auth-bypass-token: ${{ env.AUTH_BYPASS_TOKEN }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
-import type {PlaywrightTestConfig} from '@playwright/test';
-import {devices} from '@playwright/test';
-
-declare const process: {env: {CI: boolean}};
+import {
+  defineConfig,
+  devices,
+  type PlaywrightTestConfig,
+} from '@playwright/test';
 
 /**
  * Read environment variables from file.
@@ -12,7 +13,7 @@ declare const process: {env: {CI: boolean}};
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+let config: PlaywrightTestConfig = defineConfig({
   testDir: './tests',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
@@ -37,8 +38,6 @@ const config: PlaywrightTestConfig = {
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -52,48 +51,6 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Chrome'],
       },
     },
-
-    // {
-    //   name: 'firefox',
-    //   use: {
-    //     ...devices['Desktop Firefox'],
-    //   },
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: {
-    //     ...devices['Desktop Safari'],
-    //   },
-    // },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: {
-    //     ...devices['Pixel 5'],
-    //   },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: {
-    //     ...devices['iPhone 12'],
-    //   },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: {
-    //     channel: 'msedge',
-    //   },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: {
-    //     channel: 'chrome',
-    //   },
-    // },
   ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
@@ -104,6 +61,37 @@ const config: PlaywrightTestConfig = {
     command: 'npm run preview',
     port: 3000,
   },
-};
+});
+
+if (process.env.URL) {
+  const use = {
+    ...config.use,
+    baseURL: process.env.URL,
+  };
+
+  if (process.env.AUTH_BYPASS_TOKEN) {
+    use.extraHTTPHeaders = {
+      'oxygen-auth-bypass-token': process.env.AUTH_BYPASS_TOKEN,
+    };
+  }
+
+  config = {
+    ...config,
+    use,
+  };
+} else {
+  config = {
+    ...config,
+    use: {
+      ...config.use,
+      baseURL: 'http://localhost:3000',
+    },
+    /* Run your local dev server before starting the tests */
+    webServer: {
+      command: 'npm run preview',
+      port: 3000,
+    },
+  };
+}
 
 export default config;


### PR DESCRIPTION
- refactor end-to-end test job into a composite action
- call the composite action from `ci.yml` and `oxygen-deployment.yml`
- upgrade `oxygen-deployment.yml` to using Hydrogen CLI over oxygenctl-actions
- generate auth bypass token in `oxygen-deployment.yml` so Playwright can run the tests against the newly created deployment