### PR TITLE
Avoid circular imports to improve HMR in Vite

### DIFF
--- a/app/components/CountrySelector.tsx
+++ b/app/components/CountrySelector.tsx
@@ -10,7 +10,7 @@ import {Heading} from '~/components/Text';
 import {IconCheck} from '~/components/Icon';
 import type {Localizations, Locale} from '~/lib/type';
 import {DEFAULT_LOCALE} from '~/lib/utils';
-import {useRootLoaderData} from '~/root';
+import {useRootLoaderData} from '~/hooks/useRootLoaderData';
 
 export function CountrySelector() {
   const fetcher = useFetcher();

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -27,7 +27,7 @@ import {
 } from '~/lib/utils';
 import {useIsHydrated} from '~/hooks/useIsHydrated';
 import {useCartFetchers} from '~/hooks/useCartFetchers';
-import {useRootLoaderData} from '~/root';
+import {useRootLoaderData} from '~/hooks/useRootLoaderData';
 
 type LayoutProps = {
   children: React.ReactNode;

--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -5,7 +5,7 @@ import {
   type LinkProps as RemixLinkProps,
 } from '@remix-run/react';
 
-import {useRootLoaderData} from '~/root';
+import {useRootLoaderData} from '~/hooks/useRootLoaderData';
 
 type LinkProps = Omit<RemixLinkProps, 'className'> & {
   className?: RemixNavLinkProps['className'] | RemixLinkProps['className'];

--- a/app/hooks/useRootLoaderData.tsx
+++ b/app/hooks/useRootLoaderData.tsx
@@ -1,0 +1,12 @@
+import {useMatches} from '@remix-run/react';
+import type {SerializeFrom} from '@shopify/remix-oxygen';
+
+import type {loader} from '~/root';
+
+/**
+ * Access the result of the root loader from a React component.
+ */
+export function useRootLoaderData() {
+  const [root] = useMatches();
+  return root?.data as SerializeFrom<typeof loader>;
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -8,7 +8,7 @@ import type {
   MenuFragment,
   ParentMenuItemFragment,
 } from 'storefrontapi.generated';
-import {useRootLoaderData} from '~/root';
+import {useRootLoaderData} from '~/hooks/useRootLoaderData';
 import {countries} from '~/data/countries';
 
 import type {I18nLocale} from './type';

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,7 +3,6 @@ import {
   type LinksFunction,
   type LoaderFunctionArgs,
   type AppLoadContext,
-  type SerializeFrom,
   type MetaArgs,
 } from '@shopify/remix-oxygen';
 import {
@@ -14,12 +13,10 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-  useMatches,
   useRouteError,
   type ShouldRevalidateFunction,
 } from '@remix-run/react';
 import {
-  ShopifySalesChannel,
   useNonce,
   UNSTABLE_Analytics as Analytics,
   getShopAnalytics,
@@ -69,11 +66,6 @@ export const links: LinksFunction = () => {
     },
     {rel: 'icon', type: 'image/svg+xml', href: favicon},
   ];
-};
-
-export const useRootLoaderData = () => {
-  const [root] = useMatches();
-  return root?.data as SerializeFrom<typeof loader>;
 };
 
 export async function loader({request, context}: LoaderFunctionArgs) {
@@ -148,7 +140,7 @@ export default function App() {
 export function ErrorBoundary({error}: {error: Error}) {
   const nonce = useNonce();
   const routeError = useRouteError();
-  const rootData = useRootLoaderData();
+  const rootData = useLoaderData<typeof loader>();
   const locale = rootData?.selectedLocale ?? DEFAULT_LOCALE;
   const isRouteError = isRouteErrorResponse(routeError);
 

--- a/app/routes/($locale).cart.tsx
+++ b/app/routes/($locale).cart.tsx
@@ -13,7 +13,7 @@ import {
 
 import {isLocalPath} from '~/lib/utils';
 import {Cart} from '~/components/Cart';
-import {useRootLoaderData} from '~/root';
+import {useRootLoaderData} from '~/hooks/useRootLoaderData';
 
 export async function action({request, context}: ActionFunctionArgs) {
   const {cart} = context;


### PR DESCRIPTION
Similar to https://github.com/Shopify/hydrogen/pull/2014

We were getting an error like the following:

```
5:53:33 PM [vite] hmr update /app/root.tsx, /app/styles/app.css?direct, /app/root.tsx?client-route=1
5:53:34 PM [vite] hmr invalidate /app/root.tsx Could not Fast Refresh. Learn more at https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react#consistent-components-exports
5:53:34 PM [vite] hmr update ./server.ts, /app/root.tsx, /app/styles/app.css?direct, /app/components/Text.tsx, /app/components/Button.tsx, /app/components/ProductCard.tsx, /app/components/Layout.tsx, /app/components/Cart.tsx, /app/components/FeaturedSection.tsx, /app/components/CountrySelector.tsx, /app/components/FeaturedProducts.tsx, /app/components/Link.tsx, /app/root.tsx?client-route=1
```

With these changes, there's no more error related to Fast Refresh.

| Before        | After         |
| ------------- | ------------- |
| <img width="406" alt="image" src="https://github.com/Shopify/hydrogen-demo-store/assets/1634092/5085b7d7-daf1-4856-a291-bb91817952d4">|<img width="406" alt="image" src="https://github.com/Shopify/hydrogen-demo-store/assets/1634092/af565152-aca5-4f62-b851-6a879616ae12">|




