### PR TITLE
Update `typographic-base` import

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,5 @@
 progress=false
 
 # Ensure Vite can optimize these deps in PNPM
-public-hoist-pattern[]=textr
 public-hoist-pattern[]=cookie
 public-hoist-pattern[]=set-cookie-parser
-public-hoist-pattern[]=content-security-policy-builder

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,7 +1,7 @@
 import {useLocation, useMatches} from '@remix-run/react';
 import type {MoneyV2} from '@shopify/hydrogen/storefront-api-types';
 import type {FulfillmentStatus} from '@shopify/hydrogen/customer-account-api-types';
-import typographicBase from 'typographic-base/index';
+import typographicBase from 'typographic-base';
 
 import type {
   ChildMenuItemFragment,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9288,11 +9288,11 @@
       }
     },
     "node_modules/content-security-policy-builder": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.1.tgz",
-      "integrity": "sha512-Bga6d4W37VMAeu3QQOorIbfEr16CIUuC8ZzKz+GecFfnBUWoU2RUdk8DTeb+ihe2BeDCs6T4PRAxFKU7lLh0mA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.2.0.tgz",
+      "integrity": "sha512-IZhbHYV3O6xBpbvuMJz0FP8s79aTz7ymq4JQVC8TMzTdRToxrupCY1C/GlzC6GaDfKvD7AceewH+LsTV5OO/Kg==",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/content-type": {

--- a/typographic-base.d.ts
+++ b/typographic-base.d.ts
@@ -1,1 +1,1 @@
-declare module 'typographic-base/index';
+declare module 'typographic-base';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,14 +13,14 @@ export default defineConfig({
   ],
   ssr: {
     optimizeDeps: {
-      include: ['typographic-base/index', 'textr'],
+      include: ['typographic-base'],
     },
   },
   optimizeDeps: {
     include: [
       'clsx',
       '@headlessui/react',
-      'typographic-base/index',
+      'typographic-base',
       'react-intersection-observer',
       'react-use/esm/useScroll',
       'react-use/esm/useDebounce',


### PR DESCRIPTION
`typographic-base` says it has ESM but it really does not. We were manually importing from `/index` because that's ESM-like but it leads to other issues. It basically imports CJS files, thus masking CJS as ESM.

Changing the import like this makes it easier to optimize the dependency.