### PR TITLE
Add a google cache domain check before hydration

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -2,11 +2,13 @@ import {RemixBrowser} from '@remix-run/react';
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-startTransition(() => {
-  hydrateRoot(
-    document,
-    <StrictMode>
-      <RemixBrowser />
-    </StrictMode>,
-  );
-});
+if (!window.location.origin.includes('webcache.googleusercontent.com')) {
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <RemixBrowser />
+      </StrictMode>,
+    );
+  });
+}


### PR DESCRIPTION
Prevents infinite redirect: https://github.com/Shopify/hydrogen/issues/1502