### PR TITLE
Fix canonical URL issue

### DIFF
--- a/app/lib/seo.server.ts
+++ b/app/lib/seo.server.ts
@@ -61,11 +61,12 @@ function root({
   };
 }
 
-function home(): SeoConfig {
+function home({url}: {url: Request['url']}): SeoConfig {
   return {
     title: 'Home',
     titleTemplate: '%s | Hydrogen Demo Store',
     description: 'The best place to buy snowboarding products',
+    url,
     robots: {
       noIndex: false,
       noFollow: false,
@@ -178,6 +179,7 @@ function product({
   return {
     title: product?.seo?.title ?? product?.title,
     description,
+    url,
     media: selectedVariant?.image,
     jsonLd: productJsonLd({product, selectedVariant, url}),
   };
@@ -259,6 +261,7 @@ function collection({
       collection?.seo?.description ?? collection?.description ?? '',
     ),
     titleTemplate: '%s | Collection',
+    url,
     media: {
       type: 'image',
       url: collection?.image?.url,

--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -43,7 +43,7 @@ export async function loader(args: LoaderFunctionArgs) {
  * Load data necessary for rendering content above the fold. This is the critical data
  * needed to render the page. If it's unavailable, the whole page should 400 or 500 error.
  */
-async function loadCriticalData({context}: LoaderFunctionArgs) {
+async function loadCriticalData({context, request}: LoaderFunctionArgs) {
   const [{shop, hero}] = await Promise.all([
     context.storefront.query(HOMEPAGE_SEO_QUERY, {
       variables: {handle: 'freestyle'},
@@ -54,7 +54,7 @@ async function loadCriticalData({context}: LoaderFunctionArgs) {
   return {
     shop,
     primaryHero: hero,
-    seo: seoPayload.home(),
+    seo: seoPayload.home({url: request.url}),
   };
 }
 


### PR DESCRIPTION
Resolves https://github.com/Shopify/hydrogen/issues/2284

> Just noticed in the Demo Store that the canonical link from getSeoMeta is not updated on path change. Other fields such as title and description are updated

This is because we missed `url` fields for home, product and collection SEO payloads.

[Before](https://screenshot.click/27-48-zd64q-pu56z.mp4) | [After](https://screenshot.click/27-50-87bzn-8xncg.mp4)

