### PR TITLE
Fix failed to execute 'insertBefore' on 'Node' in developement

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -57,7 +57,6 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 export const links: LinksFunction = () => {
   return [
-    {rel: 'stylesheet', href: styles},
     {
       rel: 'preconnect',
       href: 'https://cdn.shopify.com',
@@ -142,6 +141,7 @@ function Layout({children}: {children?: React.ReactNode}) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <meta name="msvalidate.01" content="A352E6A0AF9A652267361BBB572B8468" />
+        <link rel="stylesheet" href={styles}></link>
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
In development, when a HMR update happens, a [Error: failed to execute 'insertBefore' on 'Node'](https://github.com/Shopify/hydrogen/issues/2586) error will occur and cause the entire page to error out.

### How to reproduce this error

1. Checkout `main` branch
2. Add a console log anywhere in the app and save. You should see a HMR update log in the terminal for app.css file
    
    <img width="649" alt="Screenshot 2025-01-09 at 9 31 59 AM" src="https://github.com/user-attachments/assets/66d459a4-bf10-4391-8d72-623cd40fd4a9" />

4. Navigate to any other url - The page will error out and in the web inspector console, you should see the error for `failed to execute 'insertBefore' on 'Node'`

On this PR, the same steps should not produce this error.