### PR TITLE
Add prefetch to sort, pagination resets and fix params mutation

### DIFF
--- a/app/components/SortFilter.tsx
+++ b/app/components/SortFilter.tsx
@@ -186,6 +186,9 @@ function getAppliedFilterLink(
     const fullKey = FILTER_URL_PREFIX + key;
     paramsClone.delete(fullKey, JSON.stringify(value));
   });
+  // Restart pagination.
+  paramsClone.delete('direction');
+  paramsClone.delete('cursor');
   return `${location.pathname}?${paramsClone.toString()}`;
 }
 
@@ -194,17 +197,26 @@ function getSortLink(
   params: URLSearchParams,
   location: Location,
 ) {
-  params.set('sort', sort);
-  return `${location.pathname}?${params.toString()}`;
+  const paramsClone = new URLSearchParams(params);
+  paramsClone.set('sort', sort);
+  // Restart pagination.
+  paramsClone.delete('direction');
+  paramsClone.delete('cursor');
+  return `${location.pathname}?${paramsClone.toString()}`;
 }
 
 function getFilterLink(
   rawInput: string | ProductFilter,
   params: URLSearchParams,
-  location: ReturnType<typeof useLocation>,
+  location: Location,
 ) {
   const paramsClone = new URLSearchParams(params);
+  // Restart pagination.
+  // Otherwise applying filters after paginating to the end results in an empty page.
+  paramsClone.delete('direction');
+  paramsClone.delete('cursor');
   const newParams = filterInputToParams(rawInput, paramsClone);
+
   return `${location.pathname}?${newParams.toString()}`;
 }
 
@@ -350,10 +362,11 @@ export default function SortMenu() {
           <Menu.Item key={item.label}>
             {() => (
               <Link
+                to={getSortLink(item.key, params, location)}
+                prefetch="intent"
                 className={`block text-sm pb-2 px-3 ${
                   activeItem?.key === item.key ? 'font-bold' : 'font-normal'
                 }`}
-                to={getSortLink(item.key, params, location)}
               >
                 {item.label}
               </Link>

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "vite-tsconfig-paths": "^4.3.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
This commit fixes:
1. possible blank pages when paginating to the end and applying filters afterwards (e.g. [last page + "out of stock" filter](https://hydrogen.shop/collections/freestyle?direction=next&cursor=eyJsYXN0X2lkIjo3OTI0NDQ4MjMxNDgwLCJsYXN0X3ZhbHVlIjoyOH0%3D&filter.available=false)), by resetting pagination.
2. mutating the search params in the getSortLink function, briefly breaking SortMenu label (or expected .get() value) until after navigation when useSearchParams is back on track.

Also adds prefetch behavior to SortMenu items.