### PR TITLE
Fix applied pagination to reset when applying filters on collections

### DIFF
--- a/app/components/SortFilter.tsx
+++ b/app/components/SortFilter.tsx
@@ -186,6 +186,8 @@ function getAppliedFilterLink(
     const fullKey = FILTER_URL_PREFIX + key;
     paramsClone.delete(fullKey, JSON.stringify(value));
   });
+  paramsClone.delete('cursor');
+  paramsClone.delete('direction');
   return `${location.pathname}?${paramsClone.toString()}`;
 }
 
@@ -195,6 +197,8 @@ function getSortLink(
   location: Location,
 ) {
   params.set('sort', sort);
+  params.delete('cursor');
+  params.delete('direction');
   return `${location.pathname}?${params.toString()}`;
 }
 
@@ -205,6 +209,8 @@ function getFilterLink(
 ) {
   const paramsClone = new URLSearchParams(params);
   const newParams = filterInputToParams(rawInput, paramsClone);
+  newParams.delete('cursor');
+  newParams.delete('direction');
   return `${location.pathname}?${newParams.toString()}`;
 }
 


### PR DESCRIPTION
Pagination needs to get reset when new filters are applied, otherwise the user sees a blank page

Fixes https://github.com/Shopify/hydrogen/issues/2774