### PR TITLE
Security: bump @remix-run/node to ^2.17.2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.6",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
-        "@remix-run/node": "^2.15.3",
+        "@remix-run/node": "^2.17.4",
         "@remix-run/react": "^2.15.3",
         "@remix-run/server-runtime": "^2.15.3",
         "@shopify/cli": "^3.74.1",
@@ -4835,6 +4835,32 @@
         }
       }
     },
+    "node_modules/@remix-run/dev/node_modules/@remix-run/node": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.15.3.tgz",
+      "integrity": "sha512-TYfS6BPhbABBpSRZ6WBA4qIWSwWvJhRVQGXCHUtgOwkuW863rcFmjh9g2Xj/IHyTmbOYPdcjHsIgZ9el4CHOKQ==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/server-runtime": "2.15.3",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2",
+        "undici": "^6.11.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/dev/node_modules/jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -4918,17 +4944,17 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.15.3.tgz",
-      "integrity": "sha512-TYfS6BPhbABBpSRZ6WBA4qIWSwWvJhRVQGXCHUtgOwkuW863rcFmjh9g2Xj/IHyTmbOYPdcjHsIgZ9el4CHOKQ==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
+      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
       "dependencies": {
-        "@remix-run/server-runtime": "2.15.3",
+        "@remix-run/server-runtime": "2.17.4",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
         "stream-slice": "^0.1.2",
-        "undici": "^6.11.1"
+        "undici": "^6.21.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -4941,6 +4967,52 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@remix-run/node/node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/@remix-run/server-runtime": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.7.2",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/turbo-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
+      "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw=="
     },
     "node_modules/@remix-run/react": {
       "version": "2.15.3",
@@ -18261,10 +18333,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
-      "license": "MIT",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@headlessui/react": "^1.7.2",
-    "@remix-run/node": "^2.15.3",
+    "@remix-run/node": "^2.17.4",
     "@remix-run/react": "^2.15.3",
     "@remix-run/server-runtime": "^2.15.3",
     "@shopify/cli": "^3.74.1",


### PR DESCRIPTION
## Summary
This PR bumps vulnerable Remix/React Router Node packages to safe versions:
- @remix-run/node >= 2.17.2
- @react-router/node >= 7.9.4
- @remix-run/deno >= 2.17.2

## Context
This addresses a security advisory for the packages above.
- https://nvd.nist.gov/vuln/detail/CVE-2025-61686


## Updated packages
- @remix-run/node@^2.17.2